### PR TITLE
Remove some dead code

### DIFF
--- a/frontend.demo/src/contracts.ts
+++ b/frontend.demo/src/contracts.ts
@@ -33,17 +33,6 @@ export function usePollManagerWithSigner(): PollManager {
   return PollManager__factory.connect(addr, eth.signer);
 }
 
-export async function usePollACL(): Promise<ComputedRef<IPollACL>> {
-  const eth = useEthereumStore();
-  const dao = usePollManager().value;
-
-  const ref = IPollACL__factory.connect(await dao.getACL(), eth.provider);
-
-  return computed(() => {
-    return ref;
-  });
-}
-
 export async function usePollManagerACL(): Promise<ComputedRef<IPollManagerACL>> {
   const eth = useEthereumStore();
   const addr = import.meta.env.VITE_CONTRACT_POLLMANAGER_ACL;

--- a/hardhat/contracts/PollManager.sol
+++ b/hardhat/contracts/PollManager.sol
@@ -127,12 +127,12 @@ contract PollManager is IERC165, IPollManager {
             || interfaceId == type(IPollManager).interfaceId;
     }
 
-    function getACL()
-        external view
-        returns (IPollManagerACL)
-    {
-        return s_managerACL;
-    }
+    // function getACL()
+    //    external view
+    //    returns (IPollManagerACL)
+    // {
+    //    return s_managerACL;
+    // }
 
     function getPollACL(bytes32 proposalId)
         external view

--- a/hardhat/interfaces/IPollManager.sol
+++ b/hardhat/interfaces/IPollManager.sol
@@ -8,7 +8,7 @@ import { IPollACL } from "./IPollACL.sol";
 interface IPollManager {
     function proxy(address voter, bytes32 proposalId, uint8 choiceId, bytes calldata in_data) external;
 
-    function getACL() external view returns (IPollManagerACL);
+    // function getACL() external view returns (IPollManagerACL);
 
     function getPollACL(bytes32 proposalId) external view returns (IPollACL);
 


### PR DESCRIPTION
In later versions, the address for poll-specific ACLs is taken from the individual polls,
not from the poll manager. Therefore, the PollManager's getACL() functionality is
no longer used.

This change removes some unused code that used to initialize Poll ACL the old way,
and also disables this unused functionality in the PollManager contract, to avoid confusion.
